### PR TITLE
react-native-vector-icons dependency version updated to avoid PropTypes error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/ataomega/react-native-multiple-select-list.git"
   },
   "dependencies": {
-    "react-native-vector-icons": "^3.0.0"
+    "react-native-vector-icons": "^4.5.0"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-multiple-select-list",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "react-native-multiple-select-list",
   "main": "multipleSelect.js",
   "scripts": {


### PR DESCRIPTION
This component uses react-native-vector-icons 3.0.0 which used React.PropTypes. Now that PropTypes has been moved out of React after React 16, an undefined error is thrown when React Native upgrade is done. In order to `import PropTypes from 'prop-types'` I have updated react-native-vector-icons to the latest version.